### PR TITLE
Allow doctrine/persistence at v3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "php": "^7.3|^8.0",
         "doctrine/data-fixtures": "^1.4",
         "doctrine/instantiator": "^1.3",
-        "doctrine/persistence": "^1.3|^2.0"
+        "doctrine/persistence": "^1.3|^2.0|^3.0"
     },
     "require-dev": {
         "doctrine/orm": "^2.7",


### PR DESCRIPTION
This pull request will allow the installation of doctrine/persistence at version ^3.0.